### PR TITLE
Add persistence storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +37,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +75,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "lazy_static"
@@ -46,11 +95,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "rtodo"
 version = "0.1.1"
 dependencies = [
  "colored",
+ "directories",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,16 @@ name = "rtodo"
 version = "0.1.1"
 edition = "2021"
 description = "A very simple to-do list manager"
-keywords = ["todo","manager","tui","to-do-list"]
+keywords = ["todo","manager","to-do-list"]
 readme = "README.md"
 license = "MIT"
 authors = ["Tiago Correia <tiagorcorreia87@gmail.com"]
 repository = "https://github.com/TiagoRCorreia/rtodo"
-categories = ["tui"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 colored = "2.0"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+directories = "4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use todos::Todo;
 
 pub mod todos;
+pub mod persistence;
 
 /// Get user input and return the value as a String
 pub fn user_input() -> Result<String, Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,7 @@ use std::process::Command;
 
 use rtodo::todos::Todo;
 use rtodo::{add_todo, main_menu, remove_todo, show_todos, sub_menu, update_todo, user_input};
-
-mod persistence;
+use rtodo::persistence;
 
 fn main() {
     // Create a vector to hold the todos

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,16 @@ use std::process::Command;
 use rtodo::todos::Todo;
 use rtodo::{add_todo, main_menu, remove_todo, show_todos, sub_menu, update_todo, user_input};
 
+mod persistence;
+
 fn main() {
     // Create a vector to hold the todos
     let mut todos: Vec<Todo> = vec![];
+
+    // Try read todos from file
+    if let Ok(vec) = persistence::read_from_file() {
+        todos.extend(vec);
+    }
 
     // Main loop
     loop {
@@ -70,6 +77,9 @@ fn main() {
             }
         // exit
         } else if user.contains('5') {
+            if let Err(e) = persistence::write_to_file(&todos) {
+                println!("Error save to file!!! {e}");
+            }
             std::process::exit(0);
         }
     } // End main loop

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,6 +1,6 @@
 use directories::BaseDirs;
 
-use rtodo::todos::Todo;
+use crate::todos::Todo;
 
 // Read todos from file
 pub fn read_from_file() -> Result<Vec<Todo>, Box<dyn std::error::Error>> {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,32 @@
+use directories::BaseDirs;
+
+use rtodo::todos::Todo;
+
+// Read todos from file
+pub fn read_from_file() -> Result<Vec<Todo>, Box<dyn std::error::Error>> {
+    // Get todos file
+    let path = BaseDirs::new().unwrap().config_dir().join("rtodo/db.json");
+    // Read todos from file as string
+    let td_str = std::fs::read_to_string(path)?;
+
+    // Create a vector of todos
+    let todos: Vec<Todo> = serde_json::from_str(&td_str)?;
+
+    // return todos
+    Ok(todos)
+}
+
+// Write todos into file
+pub fn write_to_file(todos: &Vec<Todo>) -> Result<(), Box<dyn std::error::Error>> {
+    // Get .config directory on Linux system
+    let path = BaseDirs::new().unwrap().config_dir().join("rtodo");
+
+    // Create rtodo directory
+    if !path.exists() {
+        std::fs::create_dir(&path)?;
+    }
+
+    // Write todos into file
+    std::fs::write(path.join("db.json"), serde_json::to_string(&todos)?)?;
+    Ok(())
+}

--- a/src/todos.rs
+++ b/src/todos.rs
@@ -1,4 +1,6 @@
+use serde_derive::{Deserialize, Serialize};
 /// Struct to keep the todos
+#[derive(Serialize, Deserialize)]
 pub struct Todo {
     pub title: String,
     pub description: String,


### PR DESCRIPTION
Added persistence storage. 

When the user exit the program todos will be saved into a file called **db.json** on directory **~/.config/rtodo** in Linux systems.
I don't have Windows or Mac for testing.

When the user starts the program it will try to load all todos from the file if not possible starts with an empty vector.

Used creates:
- [serde](https://crates.io/crates/serde)
- [serde_json](https://crates.io/crates/serde_json)
- [serde_derive](https://crates.io/crates/serde_derive)
- [directories](https://crates.io/crates/directories)

@cndofx  what do you think about that?
