### PR TITLE
use crossterm for cross platform terminal clearing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +422,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +445,18 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mio"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
 
 [[package]]
 name = "nix"
@@ -453,6 +500,29 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -524,12 +594,13 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "rtodo"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "colored",
+ "crossterm",
  "csv",
  "ctrlc",
  "directories",
@@ -558,6 +629,12 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
@@ -592,6 +669,42 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ chrono = { version = "0.4", features = ["serde"] }
 csv = "1.1.6"
 thiserror = "1.0.38"
 anyhow = "1.0.68"
+crossterm = "0.26.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use colored::{ColoredString, Colorize};
+use crossterm::{cursor, terminal, ExecutableCommand};
 
 use std::io::{self, Write};
-use std::process::Command;
 
 use anyhow::Result;
 use chrono::Utc;
@@ -76,7 +76,7 @@ pub fn sub_menu(todos: &mut Vec<Todo>) -> Result<bool> {
         .to_string();
 
     if id.contains('1') {
-        show_todos(todos);
+        show_todos(todos)?;
         Ok(false)
     } else if id.contains('2') {
         add_todo(todos)?;
@@ -126,9 +126,11 @@ pub fn add_todo(td: &mut Vec<Todo>) -> Result<()> {
 }
 
 /// Show todos in a formatted table
-pub fn show_todos(todos: &mut [Todo]) {
+pub fn show_todos(todos: &mut [Todo]) -> Result<()> {
     // Clear the screen
-    Command::new("clear").status().unwrap();
+    std::io::stdout()
+        .execute(terminal::Clear(terminal::ClearType::All))?
+        .execute(cursor::MoveTo(0, 0))?;
 
     println!(
         "{:^10} {:^40} {:^40} {:^10} {:^32}",
@@ -182,6 +184,8 @@ pub fn show_todos(todos: &mut [Todo]) {
             );
         }
     }
+
+    Ok(())
 }
 
 /// Removes todo with the given ID from the list

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,9 @@
 //! add new features and help me learn Rust.
 
 use colored::Colorize;
+use crossterm::{cursor, terminal, ExecutableCommand};
 use rtodo::commands::execute_commands;
 
-use std::process::Command;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -54,7 +54,12 @@ fn main() {
         // Handler loop
         while running.load(Ordering::SeqCst) {
             // Clear the screen
-            Command::new("clear").status().unwrap();
+            // Command::new("clear").status().unwrap();
+            std::io::stdout()
+                .execute(terminal::Clear(terminal::ClearType::All))
+                .unwrap()
+                .execute(cursor::MoveTo(0, 0))
+                .unwrap();
 
             // Show main menu
             main_menu();
@@ -74,7 +79,7 @@ fn main() {
 
             // Open sub menu / show todos
             if user.contains('1') {
-                show_todos(&mut todos);
+                show_todos(&mut todos).unwrap();
 
                 // Display the sub menu in a loop
                 while let Ok(e) = sub_menu(&mut todos) {
@@ -82,7 +87,7 @@ fn main() {
                     if !e {
                         break;
                     }
-                    show_todos(&mut todos);
+                    show_todos(&mut todos).unwrap();
                 }
             // add todo
             } else if user.contains('2') {
@@ -91,13 +96,13 @@ fn main() {
                 }
             // update todo
             } else if user.contains('3') {
-                show_todos(&mut todos);
+                show_todos(&mut todos).unwrap();
                 if let Err(e) = update_todo(&mut todos) {
                     eprintln!("{e}");
                 }
             // remove todo
             } else if user.contains('4') {
-                show_todos(&mut todos);
+                show_todos(&mut todos).unwrap();
                 if let Err(e) = remove_todo(&mut todos) {
                     eprintln!("{e}");
                 }


### PR DESCRIPTION
Very small change here, I just replaced both occurrences  `Command::new("clear")` with a crossterm command. I'm also looking at implementing the alternate screen and raw key event handling, probably in this same PR? Error handling in main could also use some work but that's a separate issue.